### PR TITLE
Add ability to read configuration from a toml file

### DIFF
--- a/diffusion.toml
+++ b/diffusion.toml
@@ -1,0 +1,4 @@
+diffusivity = 10.0
+n_points = 9
+stop_time = 5.0
+width = 100.0

--- a/roadshow_diffusion.py
+++ b/roadshow_diffusion.py
@@ -1,3 +1,6 @@
+import os
+import tomllib
+
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -63,6 +66,13 @@ def run_diffusion_model(diffusivity=100.0, width=100.0, stop_time=1.0, n_points=
 
 if __name__ == "__main__":
     print("Diffusion model")
-    concentration = run_diffusion_model()
+
+    if os.path.isfile("diffusion.toml"):
+        with open("diffusion.toml", "rb") as stream:
+            params = tomllib.load(stream)
+    else:
+        params = {}
+
+    concentration = run_diffusion_model(**params)
 
     print(concentration)

--- a/roadshow_diffusion.py
+++ b/roadshow_diffusion.py
@@ -64,15 +64,19 @@ def run_diffusion_model(diffusivity=100.0, width=100.0, stop_time=1.0, n_points=
     return concentration
 
 
-if __name__ == "__main__":
-    print("Diffusion model")
-
-    if os.path.isfile("diffusion.toml"):
-        with open("diffusion.toml", "rb") as stream:
+def load_params(filepath):
+    if os.path.isfile(filepath):
+        with open(filepath, "rb") as stream:
             params = tomllib.load(stream)
     else:
         params = {}
+    return params
 
+
+if __name__ == "__main__":
+    print("Diffusion model")
+
+    params = load_params("diffusion.toml")
     concentration = run_diffusion_model(**params)
 
     print(concentration)

--- a/roadshow_diffusion.py
+++ b/roadshow_diffusion.py
@@ -64,19 +64,20 @@ def run_diffusion_model(diffusivity=100.0, width=100.0, stop_time=1.0, n_points=
     return concentration
 
 
-def load_params(filepath):
-    if os.path.isfile(filepath):
-        with open(filepath, "rb") as stream:
-            params = tomllib.load(stream)
-    else:
-        params = {}
+def load_params_from_path(filepath):
+    with open(filepath, "rb") as stream:
+        params = tomllib.load(stream)
     return params
 
 
 if __name__ == "__main__":
     print("Diffusion model")
+    filepath = "diffusion.toml"
 
-    params = load_params("diffusion.toml")
+    if os.path.isfile(filepath):
+        params = load_params_from_path(filepath)
+    else:
+        params = {}
     concentration = run_diffusion_model(**params)
 
     print(concentration)


### PR DESCRIPTION
I've added the ability to read the model configuration parameters from a *toml* file. When *roadshow_diffusion* is run as a script, configuration is read from a file named `diffusion.toml`. If that file doesn't exist, the default configuration is used. 