### PR TITLE
Print ASCII plots when run as script

### DIFF
--- a/roadshow_diffusion.py
+++ b/roadshow_diffusion.py
@@ -75,7 +75,14 @@ def load_params_from_path(filepath):
 
 
 if __name__ == "__main__":
-    print("Diffusion model")
+    import matplotlib as mpl
+    import mpl_ascii
+
+    mpl_ascii.AXES_WIDTH=70
+    mpl_ascii.AXES_HEIGHT=15
+
+    mpl.use("module://mpl_ascii")
+
     filepath = "diffusion.toml"
 
     if os.path.isfile(filepath):

--- a/roadshow_diffusion.py
+++ b/roadshow_diffusion.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import tomllib
 
 import numpy as np
@@ -91,4 +92,4 @@ if __name__ == "__main__":
         params = {}
     concentration = run_diffusion_model(**params)
 
-    print(concentration)
+    np.savetxt(sys.stdout, concentration, fmt="%.6f")

--- a/roadshow_diffusion.py
+++ b/roadshow_diffusion.py
@@ -19,9 +19,9 @@ def step_like(x, step_at=0):
     return y
 
 
-def plot_profile(concentration, grid, color="r"):
+def plot_profile(x, concentration, color="r"):
     plt.figure()
-    plt.plot(grid, concentration, color)
+    plt.plot(x, concentration, color)
     plt.xlabel("x")
     plt.ylabel("C")
     plt.title("Concentration profile")
@@ -60,6 +60,10 @@ def run_diffusion_model(diffusivity=100.0, width=100.0, stop_time=1.0, n_points=
     concentration = diffuse_until(
         initial_concentration, stop_time, dx=dx, diffusivity=diffusivity
     )
+
+    plot_profile(x, initial_concentration, "g")
+    plot_profile(x, concentration, "r")
+    plt.show()
 
     return concentration
 


### PR DESCRIPTION
When *roadshow_diffusion* is run as a script, it will now print output as ASCII graphs using the *matplotlib* ASCII backend.