### PR TITLE
Replace numpy.roll with indexed arrays

### DIFF
--- a/notebooks/diffusion-model.ipynb
+++ b/notebooks/diffusion-model.ipynb
@@ -188,7 +188,8 @@
    "source": [
     "Loop over the time steps of the model,\n",
     "solving the diffusion equation using the FTCS scheme described above.\n",
-    "The boundary conditions are clamped, so reset them after each time step."
+    "Note the use of array operations on the concentration `C`.\n",
+    "The boundary conditions remain fixed in each time step."
    ]
   },
   {
@@ -198,14 +199,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Cm1 = np.empty_like(C)\n",
-    "Cp1 = np.empty_like(C)\n",
     "for t in range(0, nt):\n",
-    "    Cm1[1:] = C[:-1]\n",
-    "    Cp1[:-1] = C[1:]\n",
-    "    C += D * dt / dx**2 * (Cm1 - 2*C + Cp1)\n",
-    "    C[0] = C_left\n",
-    "    C[-1] = C_right"
+    "    C[1:-1] += D * dt / dx**2 * (C[:-2] - 2*C[1:-1] + C[2:])"
    ]
   },
   {

--- a/notebooks/diffusion-model.ipynb
+++ b/notebooks/diffusion-model.ipynb
@@ -198,8 +198,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "Cm1 = np.empty_like(C)\n",
+    "Cp1 = np.empty_like(C)\n",
     "for t in range(0, nt):\n",
-    "    C += D * dt / dx**2 * (np.roll(C, 1) - 2*C + np.roll(C, -1))\n",
+    "    Cm1[1:] = C[:-1]\n",
+    "    Cp1[:-1] = C[1:]\n",
+    "    C += D * dt / dx**2 * (Cm1 - 2*C + Cp1)\n",
     "    C[0] = C_left\n",
     "    C[-1] = C_right"
    ]


### PR DESCRIPTION
In this PR, I swapped the calls to `numpy.roll`, which caused some confusion in class, for near-equivalents done with array indexing (one differs in the first element; the other in the last). This may also help make it clearer that we're doing array operations in the model time loop.